### PR TITLE
List style fixes in bootcamp

### DIFF
--- a/uno-bootcamp/modules/01-Introduction-to-Uno/README.md
+++ b/uno-bootcamp/modules/01-Introduction-to-Uno/README.md
@@ -51,13 +51,13 @@ Instead the Uno Platform provides a common set of layout and controls, designed 
 ![Create a new project that uses the Cross-Platform App (Uno Platform) template](create-a-new-project.png)
 
 1. Launch Visual Studio for Windows (any edition).
-1. Navigate to `File -> New -> Project`.
-1. Search for `Uno`.
-1. Select `Cross-Platform App (Uno Platform)`.
-1. Name the Project name as `Todo`.
-1. Specify the Location as a folder in the workshop git repository.
-1. Press `Create` to generate your Uno application.
-1. Make sure to add Newtonsoft.Json package to all heads, and Uno.Wasm.WebSockets to the Wasm head.
+2. Navigate to `File -> New -> Project`.
+3. Search for `Uno`.
+4. Select `Cross-Platform App (Uno Platform)`.
+5. Name the Project name as `Todo`.
+6. Specify the Location as a folder in the workshop git repository.
+7. Press `Create` to generate your Uno application.
+8. Make sure to add Newtonsoft.Json package to all heads, and Uno.Wasm.WebSockets to the Wasm head.
 
 ## 💡 Project Structure
 
@@ -96,12 +96,12 @@ Here's the rule of thumb (tm):
 ![Uno Platform Dependencies](uno-platform-dependencies.png)
 
 1. Right Click `Solution 'Todo'` in Solution Explorer
-1. Click `Manage NuGet Packages for Solution`
-1. Navigate to the Updates tab
-1. Update `Uno.UI`
-1. Update `Uno.Core`
-1. Update `Uno.UniversalImageLoader`
-1. Update `Uno.Wasm.Bootstrap`
+2. Click `Manage NuGet Packages for Solution`
+3. Navigate to the Updates tab
+4. Update `Uno.UI`
+5. Update `Uno.Core`
+6. Update `Uno.UniversalImageLoader`
+7. Update `Uno.Wasm.Bootstrap`
 
 ## 💡 Uno Platform Dependencies
 

--- a/uno-bootcamp/modules/02-Leverage-existing-tools/README.md
+++ b/uno-bootcamp/modules/02-Leverage-existing-tools/README.md
@@ -15,9 +15,9 @@ In this module, you'll be (re)introduced to three key tools and learn the most p
 ![Uno Project Structure](../01-Introduction-to-Uno/uno-project-structure.png)
 
 1. Right-click on the `Todo.UWP` application and select `Set as Startup Project`.
-1. Right-click on the `Todo.UWP` application and select `Deploy`.
-1. Ensure the platform selector is set to `Todo.UWP`.
-1. Navigate to `Debug -> Start Debugging` to launch the application.
+2. Right-click on the `Todo.UWP` application and select `Deploy`.
+3. Ensure the platform selector is set to `Todo.UWP`.
+4. Navigate to `Debug -> Start Debugging` to launch the application.
 
 <!-- E&C is currently broken in VS2019
 

--- a/uno-bootcamp/modules/03-Let-views-do-views/README.md
+++ b/uno-bootcamp/modules/03-Let-views-do-views/README.md
@@ -43,14 +43,14 @@ The first step to mastering the Model-View-ViewModel software design pattern is 
 There are nine concerns that require domain modeling:
 
 1. [ ] A way to add items to the todo list.
-1. [ ] A list of todo items.
-1. [ ] Each todo item has a boolean status - incomplete or complete.
-1. [ ] Each todo item has a description that can be changed.
-1. [ ] Each todo item has a way to delete it.
-1. [ ] A count of the number of incomplete items that remain.
-1. [ ] A count of the total number of items.
-1. [ ] Commands that filter the list of todo items - all, active, and completed.
-1. [ ] A command that clears all completed items.
+2. [ ] A list of todo items.
+3. [ ] Each todo item has a boolean status - incomplete or complete.
+4. [ ] Each todo item has a description that can be changed.
+5. [ ] Each todo item has a way to delete it.
+6. [ ] A count of the number of incomplete items that remain.
+7. [ ] A count of the total number of items.
+8. [ ] Commands that filter the list of todo items - all, active, and completed.
+9. [ ] A command that clears all completed items.
 
 </p>
 </details><br/>
@@ -63,12 +63,12 @@ Now that you have modeled the domain, it is time to think about what that the us
 There are seven application behaviors:
 
 1. [ ] When there are no items in the todo list - the majority of all controls are hidden.
-1. [ ] When an item is added to the todo list — the item is added to the top of the list.
-1. [ ] When an item is marked as complete — the todo item is struck out.
-1. [ ] When an item is deleted — the todo item disappears.
-1. [ ] When the boolean status of todo item changes — the number of todo items left updates automatically.
-1. [ ] The buttons filter the todo list — display all, display only active and display only completed.
-1. [ ] When the clear completed button is pressed — all completed items are removed from the todo list.
+2. [ ] When an item is added to the todo list — the item is added to the top of the list.
+3. [ ] When an item is marked as complete — the todo item is struck out.
+4. [ ] When an item is deleted — the todo item disappears.
+5. [ ] When the boolean status of todo item changes — the number of todo items left updates automatically.
+6. [ ] The buttons filter the todo list — display all, display only active and display only completed.
+7. [ ] When the clear completed button is pressed — all completed items are removed from the todo list.
 
 </p>
 </details><br/>

--- a/uno-bootcamp/modules/04-Create-rich-responsive-UIs/README.md
+++ b/uno-bootcamp/modules/04-Create-rich-responsive-UIs/README.md
@@ -62,7 +62,7 @@ In Visual Studio, a `shared project` is just a list of files. Referencing a `sha
 The Uno Platform provides you with two techniques to conditionally implement platform-specific code within a shared project:
 
 1. [Platform-specific C# code in Uno][platform-specific-csharp].
-1. [Platform-specific XAML markup in Uno][platform-specific-xaml].
+2. [Platform-specific XAML markup in Uno][platform-specific-xaml].
 
 ## 💡 ValueConverters
 
@@ -154,8 +154,8 @@ namespace TodoApp.Wasm
 You won't need to implement the datastore or model the entities, that has been done for you.
 
 1. [ ] Review [TodoApp.Shared/ViewModels/MainPageViewModel.cs][src-viewmodel]
-1. [ ] Implement [TodoApp/TodoApp.Shared/*.xaml][src-xaml]
-1. [ ] Implement [TodoApp/TodoApp.Shared/*.xaml.cs][src-xaml-cs]
+2. [ ] Implement [TodoApp/TodoApp.Shared/*.xaml][src-xaml]
+3. [ ] Implement [TodoApp/TodoApp.Shared/*.xaml.cs][src-xaml-cs]
 
 ## 🎯 Use `VisualBoundsPadding` to manage the notch
 
@@ -168,8 +168,8 @@ As you can see, the **TODOS** header is placed under the device notch.
 To fix this problem, Uno offers you a nice tool called the `VisualBoundsPadding`. The goal of this tool is to add padding to content you don't want to be altered by the notch.
 
 1. Add the namespace declaration `xmlns:toolkit="using:Uno.UI.Toolkit"` to your XAML file
-1. Add `toolkit:VisibleBoundsPadding.PaddingMask="Top"` to your _Header_ `<Grid>`
-1. Add `toolkit:VisibleBoundsPadding.PaddingMask="Left,Right"` to your _Content_ `<Grid>`
+2. Add `toolkit:VisibleBoundsPadding.PaddingMask="Top"` to your _Header_ `<Grid>`
+3. Add `toolkit:VisibleBoundsPadding.PaddingMask="Left,Right"` to your _Content_ `<Grid>`
 
 The result will look like this and will follow the requirement of the platform vendor:
 

--- a/uno-bootcamp/modules/05-Native-intercompatibility/README.md
+++ b/uno-bootcamp/modules/05-Native-intercompatibility/README.md
@@ -47,14 +47,14 @@ As views in Uno inherit directly from native views on Android/iOS, they need to 
 There are two code layout techniques that can be used to implement platform-specific code with the Uno Platform:
 
 1. Place platform-specific code in a file that is only included in the desired `platform head`.
-1. Use conditionals within a file within the `shared project` to conditionally implement platform-specific code.
+2. Use conditionals within a file within the `shared project` to conditionally implement platform-specific code.
 
 In Visual Studio, a `shared project` is just a list of files. Referencing a `shared project` in an ordinary `.csproj` project causes those files to be included in the project. They're treated in exactly the same way as the files inside the project.
 
 The Uno Platform provides you with two techniques to conditionally implement platform-specific code within a shared project:
 
 1. [Platform-specific C# code in Uno][platform-specific-csharp].
-1. [Platform-specific XAML markup in Uno][platform-specific-xaml].
+2. [Platform-specific XAML markup in Uno][platform-specific-xaml].
 
 ## 💡 Platform-specific controls in Uno
 
@@ -108,13 +108,13 @@ The implementation of iOS and Android has been done for you. You'll need to do t
 ```
 
 1. [ ] Review [TodoApp/TodoApp.Shared/*.xaml][src-xaml]
-1. [ ] Review [TodoApp/TodoApp.Shared/*.xaml.cs][src-xaml-cs]
-1. [ ] Review [TodoApp/TodoApp.SharedControls/NativeProgress.md][src-controls]
-1. [ ] Review [TodoApp/TodoApp.SharedControls/NativeProgress.cs][src-controls]
-1. [ ] Review [TodoApp/TodoApp.SharedControls/NativeProgress.Droid.cs][src-controls]
-1. [ ] Review [TodoApp/TodoApp.SharedControls/NativeProgress.iOS.cs][src-controls]
-1. [ ] Review [TodoApp/TodoApp.SharedControls/NativeProgress.UWP.cs][src-controls]
-1. [ ] Implement [TodoApp/TodoApp.SharedControls/NativeProgress.WASM.cs][src-controls]
+2. [ ] Review [TodoApp/TodoApp.Shared/*.xaml.cs][src-xaml-cs]
+3. [ ] Review [TodoApp/TodoApp.SharedControls/NativeProgress.md][src-controls]
+4. [ ] Review [TodoApp/TodoApp.SharedControls/NativeProgress.cs][src-controls]
+5. [ ] Review [TodoApp/TodoApp.SharedControls/NativeProgress.Droid.cs][src-controls]
+6. [ ] Review [TodoApp/TodoApp.SharedControls/NativeProgress.iOS.cs][src-controls]
+7. [ ] Review [TodoApp/TodoApp.SharedControls/NativeProgress.UWP.cs][src-controls]
+8. [ ] Implement [TodoApp/TodoApp.SharedControls/NativeProgress.WASM.cs][src-controls]
 
 ## 📚 Additional Reading Material
 

--- a/uno-bootcamp/modules/07-Working-with-Uno/README.md
+++ b/uno-bootcamp/modules/07-Working-with-Uno/README.md
@@ -15,9 +15,9 @@ This module will introduce to the internals of the Uno Platform code-base. The t
 ### What's implemented
 
 1. 🎯 Visit [uno/src/Uno.UI/Generated][src-unoui-generated] to learn what features are implemented and consumed by the program that generates the Uno Platform's documentation.
-1. 📚 What is `Uno.NotImplemented`? Note that you can make not implemented APIs fatal exceptions by setting `ApiInformation.IsFailWhenNotImplemented = true`.
-1. 📚 What is the UWP Sync Generator?
-1. 📚 What is the purpose of the Generated folder?
+2. 📚 What is `Uno.NotImplemented`? Note that you can make not implemented APIs fatal exceptions by setting `ApiInformation.IsFailWhenNotImplemented = true`.
+3. 📚 What is the UWP Sync Generator?
+4. 📚 What is the purpose of the Generated folder?
 
 ### UI implementations
 
@@ -27,13 +27,13 @@ This module will introduce to the internals of the Uno Platform code-base. The t
 ### Source code generation
 
 1. 🎯 Visit the source code at [uno/src/SourceGenerators][src-sourcegenerators]
-1. 🎯 Read https://github.com/unoplatform/uno/pull/1241/files
+2. 🎯 Read https://github.com/unoplatform/uno/pull/1241/files
 
 ### Integration Tests
 
 1. 🎯 Visit [the samples app][samples-app-wasm] which is deployed from `master` after every commit.
-1. 🎯 Visit source code at [uno/src/SamplesApp][src-samples-app]
-1. 📚 If you contribute a pull-request, then we [expect tests][src-content-dialog-tests] to be included. This is our north star golden example of automated integration test w/droid, ios, wasm heads, and screenshot targeting
+2. 🎯 Visit source code at [uno/src/SamplesApp][src-samples-app]
+3. 📚 If you contribute a pull-request, then we [expect tests][src-content-dialog-tests] to be included. This is our north star golden example of automated integration test w/droid, ios, wasm heads, and screenshot targeting
 
 ### Visual Studio Solution Filters
 
@@ -124,31 +124,31 @@ If after enabling `UnoNugetOverrideVersion` you don't see the expected results c
 ## 🎯 Vendoring Uno
 
 1. Fork the Uno Platform source code from GitHub.
-1. Configure the NuGet package override to use the same version used in the Todo app.
-1. Make the required changes to the Uno Platform source code.
-1. Commit your changes to your fork of the Uno Platform.
-1. Build the Uno Platform in Visual Studio for Windows.
-1. Load the Todo application in Visual Studio for Windows.
+2. Configure the NuGet package override to use the same version used in the Todo app.
+3. Make the required changes to the Uno Platform source code.
+4. Commit your changes to your fork of the Uno Platform.
+5. Build the Uno Platform in Visual Studio for Windows.
+6. Load the Todo application in Visual Studio for Windows.
 
 ## 🎯 Source level step debugging
 
 1. Clone the Uno Platform source code from GitHub.
-1. Configure the NuGet package override to use the same version used in the Todo app.
-1. Build the Uno Platform in Visual Studio for Windows.
-1. Load the Todo application in Visual Studio for Windows.
-1. Set debug points, step in and out.
+2. Configure the NuGet package override to use the same version used in the Todo app.
+3. Build the Uno Platform in Visual Studio for Windows.
+4. Load the Todo application in Visual Studio for Windows.
+5. Set debug points, step in and out.
 
 
 ### 🎯 Debugging the source generator
 
 1. Create a side app and note which version of `Uno.UI` is used as a `PackageReference`
-1. [Override](https://github.com/unoplatform/uno/blob/7f003e13f34f899a4b9ac04552317920f961247a/src/crosstargeting_override.props.sample#L45) the NuGet package cache and use the same version for `Uno.UI` as is used in the side app.
-1. Build the side application which will start an initial `Uno.SourceGenerationHost.exe` process
-1. Attach to all the `Uno.SourceGenerationHost.exe` processes (there may be many) from the `Uno.UI` solution
-1. Rebuild the side app
-1. Your breakpoints in the source generators will hit
-1. Output from the generator is stored at `obj\Debug\netstandard2.0\g\XamlCodeGenerator`
-1. If you need to restart debugging after making significant code changes to the source generator, then make sure you terminate all existing processes (`taskkill /fi "imagename eq Uno.SourceGeneration.Host.exe" /f /t`) in between development iterations.
+2. [Override](https://github.com/unoplatform/uno/blob/7f003e13f34f899a4b9ac04552317920f961247a/src/crosstargeting_override.props.sample#L45) the NuGet package cache and use the same version for `Uno.UI` as is used in the side app.
+3. Build the side application which will start an initial `Uno.SourceGenerationHost.exe` process
+4. Attach to all the `Uno.SourceGenerationHost.exe` processes (there may be many) from the `Uno.UI` solution
+5. Rebuild the side app
+6. Your breakpoints in the source generators will hit
+7. Output from the generator is stored at `obj\Debug\netstandard2.0\g\XamlCodeGenerator`
+8. If you need to restart debugging after making significant code changes to the source generator, then make sure you terminate all existing processes (`taskkill /fi "imagename eq Uno.SourceGeneration.Host.exe" /f /t`) in between development iterations.
 
 ## 📚 Additional Reading Material
 

--- a/uno-bootcamp/modules/99-Ship-your-app/README.md
+++ b/uno-bootcamp/modules/99-Ship-your-app/README.md
@@ -1,6 +1,6 @@
 # Ship it!
 
-Congratulation! Your _TODO App_ is now completed.
+Congratulations! Your _TODO App_ is now completed.
 
 It's now time to ship it to different stores and push the WASM version on a web site for everybody to appreciate it.
 


### PR DESCRIPTION
When I was reading the docs I was bugged by the lists not being numbered. GitHub automatically renders this:

```
1. Step one
1. Step two
1. Step three
```
as a numbered list. But when you're reading it on a platform that doesn't, or directly as a file, it looks confusing. Specially the latter. Also, I found this style to be mixed between different files. Some parts numbered the list correctly and others didn't. So this should make it a bit more consitent.

Also, a small typo I found.  