### PR TITLE
adding .DS_Store to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -332,3 +332,6 @@ ASALocalRun/
 # Cake
 !tools/packages.config
 tools/*
+
+# to ignore the .DS_Store files automatically created in a Mac
+.DS_Store


### PR DESCRIPTION
.DS_Store files are auto generated when the source code goes to a Mac System.
to ignore them, inclusion of .DS_Store in .gitignore is a must.