### PR TITLE
Update Creating-the-Layout.md

### DIFF
--- a/simple-calc/modules/Resources/XAML/Creating-the-Layout.md
+++ b/simple-calc/modules/Resources/XAML/Creating-the-Layout.md
@@ -123,7 +123,7 @@ Replace the `<!--Keypad-->` comment with the following XAML:
 ```xml
 <!--Keypad-->
 <Grid 
-    Grid.Row="2" 
+    Grid.Row="3" 
     RowSpacing="16"
     ColumnSpacing="16"
     Padding="16"


### PR DESCRIPTION
In the MVUX section 03 Crerating the Layout, the Keypad grid's Row is 3 not 2.

<!---
    Thank you for contributing to Uno.
    Fields marked with (*) are required. Please don't remove the template.
-->

## Description (*)
<!---
   In the MVUX section 03 Crerating the Layout, the Keypad grid's Row is 3 not 2.
-->

## Fixed Issues (if necessary)
<!---
    In the MVUX section 03 Crerating the Layout, the Keypad grid's Row is 3 not 2.
-->

## Screenshots (if necessary)
<!---
  Provide relevant screenshots for the error fixed or the feature introduced. You can upload JPEGs, PNGs, or GIFs.
-->

## Contribution checklist (*)
 - [x] I have read the Contributing Guidelines
 - [x] Commits have been made with meaningful commit messages
 - [x] All automated tests have passed successfully 
