### PR TITLE
docs: Fix SimpleCalc xaml keypad grid

### DIFF
--- a/simple-calc/modules/Resources/XAML/Creating-the-Layout.md
+++ b/simple-calc/modules/Resources/XAML/Creating-the-Layout.md
@@ -123,7 +123,7 @@ Replace the `<!--Keypad-->` comment with the following XAML:
 ```xml
 <!--Keypad-->
 <Grid 
-    Grid.Row="2" 
+    Grid.Row="3" 
     RowSpacing="16"
     ColumnSpacing="16"
     Padding="16"


### PR DESCRIPTION
<!---
    Thank you for contributing to Uno.
    Fields marked with (*) are required. Please don't remove the template.
-->

## Description (*)

Output and Keypad section were being defined on the same grid row which cause them to overlap each other.

## Contribution checklist (*)
 - [X] I have read the Contributing Guidelines
 - [X] Commits have been made with meaningful commit messages
 - [ ] All automated tests have passed successfully 
