### PR TITLE
Typo: SimpleCalc 04-App Architecture

### DIFF
--- a/simple-calc/modules/MVUX-XAML/04-App Architecture/README.md
+++ b/simple-calc/modules/MVUX-XAML/04-App Architecture/README.md
@@ -12,7 +12,7 @@ public partial class MainPage : Page
     public MainPage()
     {
         InitializeComponent();
-        DataContext = new MainViewModel();
+        DataContext = new MainModel();
     }
 }
 ```


### PR DESCRIPTION
Updating DataContext snippet to MainModel instead of MainViewModel


## Description (*)
The MVUX SimpleCalculator docs incorrectly said to create a MainViewModel, instead of a MainModel

## Fixed Issues (if necessary)
I'm not aware of any open issue. 

## Screenshots (if necessary)


## Contribution checklist (*)
 - [x] I have read the Contributing Guidelines
 - [x] Commits have been made with meaningful commit messages
 - [ ] All automated tests have passed successfully 
