### PR TITLE
Tube Player: Standardize on Services for folder name and namespace 

### DIFF
--- a/tube-player/modules/03-Connect-UI-with-mock-data/README.md
+++ b/tube-player/modules/03-Connect-UI-with-mock-data/README.md
@@ -12,7 +12,7 @@ In this module, you will create models and services that will be used by the pre
 
 ## Add mock data service
 
-In the *Business* folder, add a class named *YoutubeServiceMockData.cs*, and replace its content with the following:
+In the *Services* folder, add a class named *YoutubeServiceMockData.cs*, and replace its content with the following:
 
 <details>
     <summary><i>YoutubeServiceMockData.cs</i> code contents (collapsed for brevity)</summary>
@@ -24,11 +24,11 @@ This class contains two constant variables that are assigned to partial JSON out
 
 ## Create service interface, mock data, mock service, and register services
 
-1. In the same folder (*Business*), create a new interface file named *IYoutubeService.cs*, that will represent our data service.
+1. In the same folder (*Services*), create a new interface file named *IYoutubeService.cs*, that will represent our data service.
     Ignore errors you might see while editing the following files, these will addressed soon by adding the missing namespaces globally.
 
     ```csharp
-    namespace TubePlayer.Business;
+    namespace TubePlayer.Services;
 
     public interface IYoutubeService
     {
@@ -36,7 +36,7 @@ This class contains two constant variables that are assigned to partial JSON out
     }
     ```
 
-1. Add another class named *YoutubeServiceMock.cs* to the *Business* folder and replace its content with the following:
+1. Add another class named *YoutubeServiceMock.cs* to the *Services* folder and replace its content with the following:
 
     <details>
         <summary><i>YoutubeServiceMock.cs</i> code contents (collapsed for brevity)</summary>

--- a/tube-player/modules/03-Connect-UI-with-mock-data/create-entities.md
+++ b/tube-player/modules/03-Connect-UI-with-mock-data/create-entities.md
@@ -38,10 +38,10 @@ In this section, you will create the entities that will be used to transfer data
     public record ChannelSearchResultData(ImmutableList<ChannelData>? Items);
     ```
 
-1. In the folder *Business* → *Models*, add a new file called *Models.cs* and replace its contents with the following code.  
+1. In the folder *Services* → *Models*, add a new file called *Models.cs* and replace its contents with the following code.  
 
     ```csharp
-    namespace TubePlayer.Business.Models;
+    namespace TubePlayer.Services.Models;
 
     public partial record YoutubeVideo(ChannelData Channel, YoutubeVideoDetailsData Details)
     {


### PR DESCRIPTION
## Description (*)
There was an inconsistency in the Tube Player steps and reference to a Business folder which doesn't exist and the user isn't told to create. It seems to me either Services or Business was a prior name and not all the references were updated, or there needs to be a step added to tell the user to create the Business folder. 

## Fixed Issues (if necessary)
None that I'm aware of. Just fixing this as I read the docs. 

## Screenshots (if necessary)


## Contribution checklist (*)
 - [ x] I have read the Contributing Guidelines
 - [x ] Commits have been made with meaningful commit messages
 - [ ] All automated tests have passed successfully 
